### PR TITLE
Bump nexus to 3.27.0-03

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.11
 LABEL maintainer="cavemandaveman <cavemandaveman@protonmail.com>"
 
 ENV SONATYPE_DIR="/opt/sonatype"
-ENV NEXUS_VERSION="3.22.1-02" \
+ENV NEXUS_VERSION="3.27.0-03" \
     NEXUS_HOME="${SONATYPE_DIR}/nexus" \
     NEXUS_DATA="/nexus-data" \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \


### PR DESCRIPTION
This bumps version to 3.27.0-03.  We'll want to bump this to 3.27.1 once they release it.

Re: https://github.com/Connectify/devops-fabric/issues/1972