### PR TITLE
Bump nexus to 3.70.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM alpine:3.11
 
-LABEL maintainer="cavemandaveman <cavemandaveman@protonmail.com>"
-
 ENV SONATYPE_DIR="/opt/sonatype"
-ENV NEXUS_VERSION="3.69.0-02" \
+ENV NEXUS_VERSION="3.70.3-01" \
     NEXUS_HOME="${SONATYPE_DIR}/nexus" \
     NEXUS_DATA="/nexus-data" \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.20
 
 ENV SONATYPE_DIR="/opt/sonatype"
 ENV NEXUS_VERSION="3.70.3-01" \


### PR DESCRIPTION
Trying to keep up with the endless parade of nexus CVEs. They dropped support for the version of java that we're using and for the database that we're using, so we'll need to update to 3.70 and migrate the database to H2 before we can upgrade beyond that. 3.70 is the last release that supports Orient DB and the version of Java we're using.